### PR TITLE
fix: remove claimed and fasttracked from ProfileUpgrade

### DIFF
--- a/types/src/main/kotlin/gg/skytils/hypixel/types/skyblock/profile.kt
+++ b/types/src/main/kotlin/gg/skytils/hypixel/types/skyblock/profile.kt
@@ -42,10 +42,7 @@ data class ProfileUpgrade(
     @SerialName("started_ms")
     val started: Long,
     val started_by: String,
-    @SerialName("claimed_ms")
-    val claimed: Long,
-    val claimed_by: String,
-    val fasttracked: Boolean
+    val claimed_by: String
 )
 
 @Serializable


### PR DESCRIPTION
Hypixel has removed these fields from the API, and it is causing errors in Skytils expecting them to exist, even though they are not used.

https://discord.com/channels/807302538558308352/807302782432051230/1315991906395750422